### PR TITLE
Fix Dracovian#33

### DIFF
--- a/module/RequestA.py
+++ b/module/RequestA.py
@@ -27,6 +27,11 @@ time.sleep: Used to pause the script for a set time.
 """
 from time import sleep
 
+"""
+json.loads: Used to convert a serialized string into a dictionary object.
+"""
+from json import loads
+
 def warn(message):
     """
     Throw a warning message without halting the script.
@@ -63,9 +68,6 @@ class DiscordRequest(object):
         Send a request to the target URL and return the response data.
         :param url: The URL to the target that we're wanting to grab data from.
         """
-
-        # Sleep for about half a second to avoid ratelimit.
-        sleep(1)
 
         # Catch HTTPError
         try:
@@ -106,6 +108,15 @@ class DiscordRequest(object):
 
             # Otherwise throw a warning message to acknowledge a failed connection.
             warn('HTTP: {0} from {1}.'.format(e.code, url))
+
+            # Handle HTTP 429 Too Many Requests
+            if e.code == 429:
+                retry_after = loads(response.read()).get('retry_after', None)
+
+                if retry_after:   
+                    # Sleep for 1 extra second as buffer
+                    sleep(1 + retry_after)
+                    return sendRequest(self, url)
 
             # Return nothing to signify a failed request.
             return None


### PR DESCRIPTION
Handle HTTP 429 using retry_after provided in HTTPResponse body. Reference: [link](https://discord.com/developers/docs/topics/rate-limits#rate-limits).
Sample response body:
```json
{
    "global": false,
    "message": "You are being rate limited.",
    "retry_after": 226.591
}
```